### PR TITLE
bump base image s2i-minimal-notebook version v0.0.6

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,7 +1,7 @@
 check:
   - thoth-build
 build:
-  base-image: "quay.io/thoth-station/s2i-minimal-notebook:v0.0.5"
+  base-image: "quay.io/thoth-station/s2i-minimal-notebook:v0.0.6"
   build-stratergy: "Source"
   registry: "quay.io"
   registry-org: "thoth-station"


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #5 

## Description

https://quay.io/repository/thoth-station/s2i-minimal-notebook?tag=v0.0.6&tab=tags
bump base image s2i-minimal-notebook version v0.0.6
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
