### PR TITLE
Configure Thoth's Kebechet to perform updates

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,0 +1,17 @@
+host: khemenu.thoth-station.ninja
+tls_verify: false
+requirements_format: pipenv
+
+runtime_environments:
+  - name: 'rhel:8'
+    operating_system:
+      name: rhel
+      version: "8"
+    python_version: "3.8"
+    recommendation_type: latest
+
+managers:
+  - name: update
+    configuration:
+      labels: [bot]
+  - name: info

--- a/kebechet-info.md
+++ b/kebechet-info.md
@@ -1,0 +1,11 @@
+---
+name: Kebechet info
+about: Obtain information about application dependencies
+title: Kebechet info
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Give me information about my dependencies, please.

--- a/kebechet-update.md
+++ b/kebechet-update.md
@@ -1,0 +1,9 @@
+---
+name: Kebechet update
+about: Manually trigger update of dependencies
+labels: bot
+---
+
+Hey, Kebechet!
+
+Update my dependencies, please.


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

This pull request adds GitHub templates and configuration for Kebechet. Kebechet will perform updates in the repository automatically by issuing new pull requests adjusting the version. As of now, updates will happen on the transitive dependencies. If you wish to update also direct dependencies, elyra, there is a need to relax requirements:

https://github.com/opendatahub-io/s2i-lab-elyra/blob/95afe3ba86df5aa257bb4662041014c97bff7ae5/Pipfile#L9

See [Kebechet documentation for more info](https://thoth-station.ninja/docs/developers/adviser/integration.html#kebechet-github-application).